### PR TITLE
Handle pin_protocol field in HmacSecretInput

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1334,6 +1334,11 @@ where UP: UserPresence,
         credential_key: KeyId,
     ) -> Result<Option<ctap2::get_assertion::ExtensionsOutput>> {
         if let Some(hmac_secret) = &extensions.hmac_secret {
+            if let Some(pin_protocol) = hmac_secret.pin_protocol {
+                if pin_protocol != 1 {
+                    return Err(Error::InvalidParameter);
+                }
+            }
 
             // We derive credRandom as an hmac of the existing private key.
             // UV is used as input data since credRandom should depend UV


### PR DESCRIPTION
The December 08, 2020 version of the Client to Authenticator Protocol
(CTAP) specification added the pinUvAuthProtocol(0x04) field to the
input data for the hmac-secret extension in the
authenticatorGetAssertion command.  This patch checks that the value of
this field (if present) is set to 1 as we only support this pin
protocol.
	https://fidoalliance.org/specs/fido-v2.1-rd-20201208/fido-client-to-authenticator-protocol-v2.1-rd-20201208.html

This is still a draft because it depends on https://github.com/solokeys/ctap-types/pull/2.