### PR TITLE
Signal credential protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# fido-authenticator
+
+Open source [FIDO][fido] authenticator implementation.
+
+Built with [Trussed][trussed].
+
+As used in the [SoloKeys][solokeys] [Solo 2][solo2] and [Nitrokey 3][nitro3].
+
+### Specifications
+
+- [Client to Authenticator Protocol (CTAP)][ctap21ps]
+- [W3C Web Authentication][webauthnl2]
+
+[fido]: https://fidoalliance.org/
+[trussed]: https://trussed.dev/
+[solokeys]: https://solokeys.com/
+[solo2]: https://solo2.dev/
+[nitro3]: https://www.nitrokey.com/news/2021/new-nitrokey-3-nfc-usb-c-rust-common-criteria-eal-6/
+[ctap21ps]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html
+[webauthnl2]: https://www.w3.org/TR/webauthn-2/
+
+#### License
+
+`fido-authenticator` is fully open source.
+
+All software, unless otherwise noted, is dual licensed under [Apache 2.0](LICENSE-APACHE) and [MIT](LICENSE-MIT).
+You may use `fido-authenticator` software under the terms of either the Apache 2.0 license or MIT license.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
+
+All documentation, unless otherwise noted, is licensed under [CC-BY-SA](https://creativecommons.org/licenses/by-sa/4.0/).
+You may use `fido-authenticator` documentation under the terms of the CC-BY-SA 4.0 license.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2077,6 +2077,7 @@ where UP: UserPresence,
 
         let mut extensions = Vec::<String<11>, 4>::new();
         // extensions.push(String::from_str("credProtect").unwrap()).unwrap();
+        extensions.push(String::from_str("credProtect").unwrap()).unwrap();
         extensions.push(String::from_str("hmac-secret").unwrap()).unwrap();
 
         let mut pin_protocols = Vec::<u8, 1>::new();

--- a/src/state.rs
+++ b/src/state.rs
@@ -139,7 +139,7 @@ impl Identity {
 
             (Some((key, cert)), aaguid.unwrap())
         } else {
-            info_now!("exist returns none");
+            info_now!("attestation key does not exist");
             (None, *b"AAGUID0123456789")
         }
     }


### PR DESCRIPTION
We were missing the entry in `GetInfo`.

Some relying parties, e.g. `ssh-keygen`, require (signaled) credential protection for resident keys with PIN not set.

Fixes https://github.com/solokeys/fido-authenticator/issues/3.