### PR TITLE
Smaller keyhandle length

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -89,7 +89,9 @@ pub struct CredentialData {
     pub key: Key,
 
     // extensions
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hmac_secret: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cred_protect: Option<CredentialProtectionPolicy>,
 
     // TODO: add `sig_counter: Option<CounterId>`,


### PR DESCRIPTION
Remove some fields from credential data serialization while making credential ID.
Reduces key handle size by around 30% (from ~320 to ~220). Tested on Gitlab, and this patch makes it working correctly (both registering and signing, as opposed to 500 error code returned otherwise).
Presumably the hidden limit is 255 bytes, which would be compatible with CTAP1.

cc @jans23 @robin-nitrokey 

To do:
- [x] remove commented code
- [x] discuss extensions fields